### PR TITLE
fix: remove storybook dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '10.10'
+  - '10.15'
 
 cache:
   - npm: true

--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -38,7 +38,6 @@
     "@storybook/addons": "^5.0.9",
     "@storybook/react": "^5.0.9",
     "@types/react": "^16.8.8",
-    "@types/storybook__addon-knobs": "^5.0.0",
     "@types/storybook__react": "3.0.7",
     "bootstrap": "^4.3.1",
     "react": "^16.6.0",


### PR DESCRIPTION
🐛 Bug Fix

Remove @types/storybook__addon-knobs because typing is supported and update node.