### PR TITLE
Fix viewport not change when filter new data

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
@@ -51,6 +51,8 @@ const defaultProps = {
 };
 
 class DeckGLContainer extends React.Component {
+  currentViewPort = null;
+
   constructor(props) {
     super(props);
     this.tick = this.tick.bind(this);
@@ -61,6 +63,7 @@ class DeckGLContainer extends React.Component {
       tooltip: null,
       viewState: props.viewport,
     };
+    this.currentViewPort = props.viewport;
   }
 
   componentWillUnmount() {
@@ -79,7 +82,12 @@ class DeckGLContainer extends React.Component {
       if (setCV) {
         setCV('viewport', this.state.viewState);
       }
+
       this.setState({ lastUpdate: null });
+    }
+    if (this.currentViewPort != null && this.currentViewPort !== this.props.viewport) {
+      this.currentViewPort = this.props.viewport;
+      this.setState({ viewState: this.props.viewport });
     }
   }
 


### PR DESCRIPTION
🐛 Bug Fix

When filter new data on dashboard, the viewport does not update so I create a temp variable to determine whether the props has changed then update the state manualy.
