### PR TITLE
fix(superset-ui-legacy-preset-chart-deckgl): fix download map as image

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
@@ -113,13 +113,13 @@ class DeckGLContainer extends React.Component {
             height={adjustedHeight}
             layers={layers}
             viewState={viewState}
-            onViewStateChange={this.onViewStateChange}
             glOptions={{ preserveDrawingBuffer: true }}
+            onViewStateChange={this.onViewStateChange}
           >
             <StaticMap
+              preserveDrawingBuffer
               mapStyle={this.props.mapStyle}
               mapboxApiAccessToken={this.props.mapboxApiAccessToken}
-              preserveDrawingBuffer
             />
           </DeckGL>
           {children}

--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/DeckGLContainer.jsx
@@ -114,10 +114,12 @@ class DeckGLContainer extends React.Component {
             layers={layers}
             viewState={viewState}
             onViewStateChange={this.onViewStateChange}
+            glOptions={{ preserveDrawingBuffer: true }}
           >
             <StaticMap
               mapStyle={this.props.mapStyle}
               mapboxApiAccessToken={this.props.mapboxApiAccessToken}
+              preserveDrawingBuffer
             />
           </DeckGL>
           {children}


### PR DESCRIPTION
Fixes downloading Scatterplot and Screen grid charts as image. Part of https://github.com/apache/superset/pull/13181

![country-of-citizenship-2021-02-17T17-02-26 826Z](https://user-images.githubusercontent.com/15073128/108240005-b8fc6780-714a-11eb-88d7-36924b13b00f.jpg)

CC: @villebro @junlincc
