### PR TITLE
chore: upgrade superset-ui peerDependencies

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/package.json
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/package.json
@@ -46,8 +46,8 @@
     "xss": "^1.0.6"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.16.3",
-    "@superset-ui/core": "^0.16.3",
+    "@superset-ui/chart-controls": "^0.17.10",
+    "@superset-ui/core": "^0.17.10",
     "react": "^15 || ^16"
   }
 }

--- a/packages/superset-ui-legacy-preset-chart-kepler/package.json
+++ b/packages/superset-ui-legacy-preset-chart-kepler/package.json
@@ -37,8 +37,8 @@
     "viewport-mercator-project": "^6.1.1"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.16.3",
-    "@superset-ui/core": "^0.16.3",
+    "@superset-ui/chart-controls": "^0.17.10",
+    "@superset-ui/core": "^0.17.10",
     "react": "^15 || ^16"
   }
 }


### PR DESCRIPTION
🏠 Internal

Upgrade peerDependencies of `superset-ui` packages to the latest.