### PR TITLE
build: add commands to release via lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "prepare-release": "git checkout master && git pull --rebase origin master && lerna bootstrap && yarn install && yarn test",
     "prerelease": "yarn build",
     "pretest": "yarn lint",
+    "release-patch-version": "yarn prepare-release && lerna version patch && lerna publish && yarn postrelease",
+    "release-minor-version": "yarn prepare-release && lerna version minor && lerna publish && yarn postrelease",
     "release": "yarn prepare-release && lerna publish --exact && yarn postrelease",
     "postrelease": "lerna run deploy-demo",
     "storybook": "cd packages/superset-ui-plugins-demo && yarn storybook"


### PR DESCRIPTION
🏆 Enhancements
🏠 Internal

`v0.4.2` seems to have been published without a tag pushed to remote (which will automatically happen if `lerna version` is used).

While a long-term solution is to setup auto-release like `superset-ui`, providing these quick yarn command shortcuts might help preventing future untracked releases.

```
yarn release-patch-version
yarn release-minor-version
```