### PR TITLE
Fix issue with large timestamp arrays

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.jsx
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.jsx
@@ -130,6 +130,9 @@ export default class CategoricalDeckGLContainer extends React.PureComponent {
         points: props.getPoints(features),
       });
     }
+    if (viewport.zoom < 0) {
+      viewport.zoom = 0;
+    }
 
     return {
       start,

--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/utils/time.js
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/utils/time.js
@@ -77,8 +77,8 @@ function getStepSeconds(step, start) {
 }
 
 export function getPlaySliderParams(timestamps, timeGrain) {
-  const minTimestamp = moment(Number(timestamps.reduce((a,b) => a<b ? a:b)));
-  const maxTimestamp = moment(Number(timestamps.reduce((a,b) => a>b ? a:b)));
+  const minTimestamp = moment(Number(timestamps.reduce((a,b) => a < b ? a : b)));
+  const maxTimestamp = moment(Number(timestamps.reduce((a,b) => a > b ? a : b)));
   let step;
   let reference;
 


### PR DESCRIPTION
This PR resolves a two issues. 

First, an issue where Math.max and Math.min produce "Maximum call stack size exceeded" errors when used with large arrays (see: https://stackoverflow.com/questions/18308700/chrome-how-to-solve-maximum-call-stack-size-exceeded-errors-on-math-max-apply). 

Second, when the chart size is very small, viewport.zoom will become negative and the base layer will not be rendered.

🐛 Bug Fix
