### PR TITLE
chore: add Highly-used tag for charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs/
 .cache
 .eslintcache
 .idea
+*.iml
 .npm
 .vscode
 .yarnclean

--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/index.js
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Scatter/index.js
@@ -27,6 +27,7 @@ const metadata = new ChartMetadata({
   name: t('deck.gl Scatterplot'),
   thumbnail,
   useLegacyApi: true,
+  tags: [t('Highly-used')],
 });
 
 export default class ScatterChartPlugin extends ChartPlugin {

--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/index.js
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Screengrid/index.js
@@ -27,6 +27,7 @@ const metadata = new ChartMetadata({
   name: t('deck.gl Screen Grid'),
   thumbnail,
   useLegacyApi: true,
+  tags: [t('Highly-used')],
 });
 
 export default class ScreengridChartPlugin extends ChartPlugin {


### PR DESCRIPTION
added `Hightly-used` tag to
1. deck.gl Scatterplot 
2. deck.gl Screen Grid

refer to: https://github.com/apache/superset/issues/15720