### PR TITLE
fix(hex): restore control panel to functioning state

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.js
@@ -17,28 +17,21 @@
  * under the License.
  */
 import { sections } from '@superset-ui/chart-controls';
-import { t, legacyValidateInteger, isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { formatSelectOptions } from '../../utilities/utils';
 import {
+  autozoom,
+  extruded,
   filterNulls,
+  gridSize,
   jsColumns,
   jsDataMutator,
-  jsTooltip,
   jsOnclickHref,
-  fillColorPicker,
-  strokeColorPicker,
-  filled,
-  stroked,
-  extruded,
-  viewport,
+  jsTooltip,
   mapboxStyle,
-  geojsonColumn,
+  spatial,
+  viewport,
 } from '../../utilities/Shared_DeckGL';
-import { dndGeojsonColumn } from '../../utilities/sharedDndControls';
-
-const geojson = isFeatureEnabled(FeatureFlag.ENABLE_EXPLORE_DRAG_AND_DROP)
-  ? dndGeojsonColumn
-  : geojsonColumn;
 
 export default {
   controlPanelSections: [
@@ -46,34 +39,42 @@ export default {
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [[geojson], ['row_limit'], [filterNulls], ['adhoc_filters']],
+      controlSetRows: [[spatial], ['size'], ['row_limit'], [filterNulls], ['adhoc_filters']],
     },
     {
       label: t('Map'),
       controlSetRows: [
         [mapboxStyle, viewport],
-        // TODO [autozoom, null], // import { autozoom } from './Shared_DeckGL'
-      ],
-    },
-    {
-      label: t('GeoJson Settings'),
-      controlSetRows: [
-        [fillColorPicker, strokeColorPicker],
-        [filled, stroked],
-        [extruded, null],
+        ['color_picker'],
+        [autozoom],
+        [gridSize],
+        [extruded],
         [
           {
-            name: 'point_radius_scale',
+            name: 'js_agg_function',
             config: {
               type: 'SelectControl',
-              freeForm: true,
-              label: t('Point Radius Scale'),
-              validators: [legacyValidateInteger],
-              default: null,
-              choices: formatSelectOptions([0, 100, 200, 300, 500]),
+              label: t('Dynamic Aggregation Function'),
+              description: t('The function to use when aggregating points into groups'),
+              default: 'sum',
+              clearable: false,
+              renderTrigger: true,
+              choices: formatSelectOptions([
+                'sum',
+                'min',
+                'max',
+                'mean',
+                'median',
+                'count',
+                'variance',
+                'deviation',
+                'p1',
+                'p5',
+                'p95',
+                'p99',
+              ]),
             },
           },
-          null,
         ],
       ],
     },


### PR DESCRIPTION
🐛 Bug Fix
During migration of control panels to this repo in #17 the Hex control panel was apparently created incorrectly. This PR restores the Hex control panel to those that were removed from `apache/superset` in https://github.com/apache/superset/pull/11564 with minor refactoring to correspond with shared controls available in this repo.

### AFTER
![image](https://user-images.githubusercontent.com/33317356/130031414-3fdd6b19-5fc8-4ea1-8971-f8dd5c19c655.png)

### BEFORE
![image](https://user-images.githubusercontent.com/33317356/130031484-e2af15f2-3256-4b89-9948-17e6c77417d7.png)
