### PR TITLE
chore: bump superset-ui peer dependencies

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/package.json
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/package.json
@@ -46,8 +46,8 @@
     "xss": "^1.0.6"
   },
   "peerDependencies": {
-    "@superset-ui/chart-controls": "^0.17.80",
-    "@superset-ui/core": "^0.17.80",
+    "@superset-ui/chart-controls": "0.x.x",
+    "@superset-ui/core": "0.x.x",
     "react": "^16.13.1"
   }
 }


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

🏠 Internal

because superset-ui had a minor bump which is incompatible with ^0.17.x
