### PR TITLE
chore: import esmodule from chart-controls

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/utilities/sharedDndControls.jsx
@@ -18,7 +18,7 @@
  */
 
 import { t } from '@superset-ui/core';
-import { dndEntity } from '@superset-ui/chart-controls/lib/shared-controls/dndControls';
+import { dndEntity } from '@superset-ui/chart-controls';
 
 export const dndLineColumn = {
   name: 'line_column',


### PR DESCRIPTION
🏠 Internal
in order to support monorepo project, so import esmodule from chart-controls
